### PR TITLE
Fix keyboard interactions jumping between values

### DIFF
--- a/src/angular/ay-slide-wheel.ts
+++ b/src/angular/ay-slide-wheel.ts
@@ -47,6 +47,7 @@ angular.module(modName, [])
         lineEndColour: '@?'
       },
       link: function($scope:IScope, $element:IAugmentedJQuery, $attrs:IAttributes, $ctrl:AySlideWheel) {
+        $ctrl.value = $ctrl.value || 0;
         new SlideWheel(
           $element[0],
           (val: number) => {

--- a/src/slide-wheel/slide-wheel.ts
+++ b/src/slide-wheel/slide-wheel.ts
@@ -14,7 +14,7 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
   const kMax = 1000;
 
   // Value ranges from 0 to 1000
-  value   = ((value - min) / (max - min)) * 1000 || 0;
+  let arcValue   = ((value - min) / (max - min)) * 1000 || 0;
 
   element.setAttribute('tabindex', '0');
   element.setAttribute('role', 'slider');
@@ -98,13 +98,11 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
   function change(v) {
     const oldval = value | 0;
     const newval = ((max - min) * (v / kMax) + min) | 0;
-    value = v;
+    arcValue = v;
 
     if (oldval !== newval) {
       element.setAttribute('aria-valuenow', newval.toString());
-      // $scope.$evalAsync(() => {
-      //   $ctrl.value = newval;
-      // });
+      value = newval;
 
       if (onChange) {
         onChange(newval);
@@ -112,11 +110,11 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
     }
   }
 
-  if (value < kMin) {
+  if (arcValue < kMin) {
     change(kMin);
   }
 
-  if (value > kMax) {
+  if (arcValue > kMax) {
     change(kMax);
   }
 
@@ -141,7 +139,7 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
   var drawing = false;
   function draw() {
     var c = context;     // context
-    var a = arc(value);  // Arc
+    var a = arc(arcValue);  // Arc
 
 
     function clearCanvas() {
@@ -237,7 +235,7 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
         evt.touches[0].pageY * adjustment
       );
 
-      if (v === value) {
+      if (v === arcValue) {
         return;
       }
 
@@ -267,7 +265,7 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
       var adjustment = width / canvas.offsetWidth;
       var v = xy2val(evt.pageX * adjustment, evt.pageY * adjustment);
 
-      if (v === value) {
+      if (v === arcValue) {
         return;
       }
 
@@ -347,7 +345,7 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
           val = min;
         }
 
-        val = ((val - min) / (max - min)) * 1000 - 1;
+        val = ((val - min) / (max - min)) * 1000;
         if (val < kMin) {
           val = kMin;
         }
@@ -391,9 +389,9 @@ export function SlideWheel(element: HTMLElement, onChange, value: number, enable
     // Make the knob not be able to cross the min/max boundary
     // has a side effect that you cant easily tap to change the value
     // when the dial is close to the max/min boundary
-    if ( (value > kMax*0.9 && ret <= kMax*0.1) || (value === kMax && ret <= kMax*0.8) ) {
+    if ( (arcValue > kMax*0.9 && ret <= kMax*0.1) || (arcValue === kMax && ret <= kMax*0.8) ) {
       ret = kMax;
-    } else if (value <= kMax*0.1 && ret > kMax*0.2) {
+    } else if (arcValue <= kMax*0.1 && ret > kMax*0.2) {
       ret = kMin;
     }
 


### PR DESCRIPTION
In the port from AngularJS, we ended up conflating two `value` variables that served different purposes. One is the actual numeric value of the widget, and one is an internal value representing the position of the slider around the arc of the wheel.

There was also an issue when using the keyboard to decrement the slider value due to rounding where it would jump down by 2 numbers (but visually put the slider in the correct(ish) spot on the wheel). That is now also resolved.